### PR TITLE
attempt to fix the github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
           pip install --upgrade pip
           pip install .
           pip install .[test]
+          rm -rf build
 
       - name: Static type checking (mypy)
         run: |


### PR DESCRIPTION
for whatever reason, ruff starts to care about the `build/` subdirectory with https://github.com/mercedes-benz/odxtools/pull/393 . Since this is probably an artifact of pip, let's just delete this directory before linting.

Andreas Lauser &lt;andreas.lauser@mercedes-benz.com&gt;, on behalf of [MBition GmbH](https://mbitionio/).
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md) 
